### PR TITLE
Filter for workspace tasks that have the type "dub"

### DIFF
--- a/src/task-provider.ts
+++ b/src/task-provider.ts
@@ -9,7 +9,9 @@ export default class DubTaskProvider implements vsc.TaskProvider {
         let tasksConfig = vsc.workspace.getConfiguration('tasks');
         let result: vsc.Task[] = [];
 
-        result = (tasksConfig.tasks || defaultTaskDefinitions).map((taskDef: DubTaskDefinition) => {
+        result = (tasksConfig.tasks || defaultTaskDefinitions)
+        .filter((taskDef: DubTaskDefinition) => taskDef.type === 'dub' )
+        .map((taskDef: DubTaskDefinition) => {
             let args = [util.dub, taskDef.task];
 
             for (let option of ['build', 'config', 'compiler', 'arch']) {


### PR DESCRIPTION
Currently the DubTaskProvider doesn't consider the type of tasks returned by `vsc.workspace.getConfiguration('tasks')`

``` json
{
	"version": "2.0.0",
	"tasks": [
		{
			"label": "hello",
			"type": "shell",
			"command": "echo 'Hello'"
		},
		{
			"label": "test",
			"type": "dub",
			"task": "test"
		}
	]
}
```

This results in an error being thrown
![snipaste_2018-12-02_21-22-22](https://user-images.githubusercontent.com/9374561/49339912-60814280-f684-11e8-9e52-08651864e055.png)
